### PR TITLE
feat: add login and register flows

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,244 @@
+"use client";
+
+import { FormEvent, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import {
+  FormButton,
+  FormCard,
+  FormField,
+  FormLayout,
+  FormLink,
+  FormRoot,
+  Toast,
+  type ToastVariant,
+} from "@/components/ui/Form";
+import { apiFetch, getApiBaseUrl } from "@/lib/api";
+import { clearToken, getToken, setToken } from "@/lib/auth";
+
+type FieldErrors = {
+  email?: string;
+  password?: string;
+};
+
+type ToastState = {
+  id: number;
+  message: string;
+  variant: ToastVariant;
+};
+
+type AuthResponse = {
+  token?: string;
+};
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export default function LoginPage() {
+  const router = useRouter();
+  const [checkingSession, setCheckingSession] = useState(true);
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [toast, setToast] = useState<ToastState | null>(null);
+
+  const showToast = (message: string, variant: ToastVariant = "error") => {
+    setToast({ id: Date.now(), message, variant });
+  };
+
+  useEffect(() => {
+    let active = true;
+    const token = getToken();
+
+    if (!token) {
+      setCheckingSession(false);
+      return;
+    }
+
+    const verifySession = async () => {
+      try {
+        const response = await apiFetch("/me", { cache: "no-store" });
+        if (!response.ok) {
+          throw new Error(`Session check failed with status ${response.status}`);
+        }
+        router.replace("/dashboard");
+      } catch (error) {
+        console.warn("Session check failed", error);
+        clearToken();
+        if (active) {
+          setCheckingSession(false);
+        }
+      }
+    };
+
+    void verifySession();
+
+    return () => {
+      active = false;
+    };
+  }, [router]);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const trimmedEmail = email.trim();
+    const nextErrors: FieldErrors = {};
+
+    if (!trimmedEmail) {
+      nextErrors.email = "请输入邮箱地址";
+    } else if (!EMAIL_REGEX.test(trimmedEmail)) {
+      nextErrors.email = "邮箱格式不正确";
+    }
+
+    if (!password) {
+      nextErrors.password = "请输入密码";
+    } else if (password.length < 6) {
+      nextErrors.password = "密码至少 6 位";
+    }
+
+    if (Object.keys(nextErrors).length > 0) {
+      setFieldErrors(nextErrors);
+      return;
+    }
+
+    setFieldErrors({});
+    setIsSubmitting(true);
+    let redirecting = false;
+
+    try {
+      const response = await apiFetch("/auth/login", {
+        method: "POST",
+        skipAuth: true,
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          email: trimmedEmail,
+          password,
+        }),
+      });
+
+      if (!response.ok) {
+        if (response.status === 401) {
+          showToast("邮箱或密码错误", "error");
+        } else {
+          showToast(`登录失败（${response.status}）`, "error");
+        }
+        return;
+      }
+
+      let token: string | undefined;
+      try {
+        const data = (await response.json()) as AuthResponse;
+        token = data?.token;
+      } catch (error) {
+        console.error("Failed to parse /auth/login response", error);
+      }
+
+      if (!token) {
+        showToast("登录失败：服务未返回访问令牌", "error");
+        return;
+      }
+
+      setToken(token);
+
+      try {
+        await apiFetch("/me", { cache: "no-store" });
+      } catch (error) {
+        console.warn("Failed to fetch /me after login", error);
+      }
+
+      redirecting = true;
+      router.replace("/dashboard");
+    } catch (error) {
+      console.error("Login request failed", error);
+      showToast("无法连接到服务器，请稍后再试", "error");
+    } finally {
+      if (!redirecting) {
+        setIsSubmitting(false);
+      }
+    }
+  };
+
+  const apiBaseUrl = getApiBaseUrl();
+  const toastElement = toast ? (
+    <Toast
+      key={toast.id}
+      open
+      message={toast.message}
+      variant={toast.variant}
+      onOpenChange={(open) => {
+        if (!open) {
+          setToast(null);
+        }
+      }}
+    />
+  ) : null;
+
+  if (checkingSession) {
+    return (
+      <FormLayout>
+        {toastElement}
+        <FormCard title="请稍候" description="正在验证当前会话…">
+          <p>我们正在为您检查登录状态，请稍后。</p>
+        </FormCard>
+      </FormLayout>
+    );
+  }
+
+  return (
+    <FormLayout>
+      {toastElement}
+      <FormRoot
+        title="登录 DNA Web"
+        description={
+          <>
+            欢迎回来！
+            <br />
+            当前 API 地址：{apiBaseUrl || "未配置"}
+          </>
+        }
+        footer={
+          <>
+            还没有账号？ <FormLink href="/register">立即注册</FormLink>
+          </>
+        }
+        onSubmit={handleSubmit}
+      >
+        <FormField
+          label="邮箱"
+          name="email"
+          type="email"
+          autoComplete="email"
+          placeholder="name@example.com"
+          value={email}
+          onChange={(event) => {
+            setEmail(event.target.value);
+            if (fieldErrors.email) {
+              setFieldErrors((prev) => ({ ...prev, email: undefined }));
+            }
+          }}
+          error={fieldErrors.email}
+        />
+        <FormField
+          label="密码"
+          name="password"
+          type="password"
+          autoComplete="current-password"
+          placeholder="至少 6 位"
+          value={password}
+          onChange={(event) => {
+            setPassword(event.target.value);
+            if (fieldErrors.password) {
+              setFieldErrors((prev) => ({ ...prev, password: undefined }));
+            }
+          }}
+          error={fieldErrors.password}
+        />
+        <FormButton disabled={isSubmitting}>
+          {isSubmitting ? "登录中…" : "登录"}
+        </FormButton>
+      </FormRoot>
+    </FormLayout>
+  );
+}

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,0 +1,292 @@
+"use client";
+
+import { FormEvent, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import {
+  FormButton,
+  FormCard,
+  FormField,
+  FormLayout,
+  FormLink,
+  FormRoot,
+  Toast,
+  type ToastVariant,
+} from "@/components/ui/Form";
+import { apiFetch, getApiBaseUrl } from "@/lib/api";
+import { clearToken, getToken, setToken } from "@/lib/auth";
+
+type FieldErrors = {
+  email?: string;
+  password?: string;
+};
+
+type ToastState = {
+  id: number;
+  message: string;
+  variant: ToastVariant;
+};
+
+type AuthResponse = {
+  token?: string;
+};
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export default function RegisterPage() {
+  const router = useRouter();
+  const [checkingSession, setCheckingSession] = useState(true);
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [toast, setToast] = useState<ToastState | null>(null);
+
+  const showToast = (message: string, variant: ToastVariant = "error") => {
+    setToast({ id: Date.now(), message, variant });
+  };
+
+  useEffect(() => {
+    let active = true;
+    const token = getToken();
+
+    if (!token) {
+      setCheckingSession(false);
+      return;
+    }
+
+    const verifySession = async () => {
+      try {
+        const response = await apiFetch("/me", { cache: "no-store" });
+        if (!response.ok) {
+          throw new Error(`Session check failed with status ${response.status}`);
+        }
+        router.replace("/dashboard");
+      } catch (error) {
+        console.warn("Session check failed", error);
+        clearToken();
+        if (active) {
+          setCheckingSession(false);
+        }
+      }
+    };
+
+    void verifySession();
+
+    return () => {
+      active = false;
+    };
+  }, [router]);
+
+  const attemptLogin = async (userEmail: string, userPassword: string) => {
+    const response = await apiFetch("/auth/login", {
+      method: "POST",
+      skipAuth: true,
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        email: userEmail,
+        password: userPassword,
+      }),
+    });
+
+    if (!response.ok) {
+      return { response, token: undefined as string | undefined };
+    }
+
+    let token: string | undefined;
+    try {
+      const data = (await response.json()) as AuthResponse;
+      token = data?.token;
+    } catch (error) {
+      console.error("Failed to parse /auth/login response after register", error);
+    }
+
+    return { response, token };
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const trimmedEmail = email.trim();
+    const nextErrors: FieldErrors = {};
+
+    if (!trimmedEmail) {
+      nextErrors.email = "请输入邮箱地址";
+    } else if (!EMAIL_REGEX.test(trimmedEmail)) {
+      nextErrors.email = "邮箱格式不正确";
+    }
+
+    if (!password) {
+      nextErrors.password = "请输入密码";
+    } else if (password.length < 6) {
+      nextErrors.password = "密码至少 6 位";
+    }
+
+    if (Object.keys(nextErrors).length > 0) {
+      setFieldErrors(nextErrors);
+      return;
+    }
+
+    setFieldErrors({});
+    setIsSubmitting(true);
+    let redirecting = false;
+
+    try {
+      const response = await apiFetch("/auth/register", {
+        method: "POST",
+        skipAuth: true,
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          email: trimmedEmail,
+          password,
+        }),
+      });
+
+      if (!response.ok) {
+        if (response.status === 409) {
+          showToast("该邮箱已被注册", "error");
+        } else {
+          showToast(`注册失败（${response.status}）`, "error");
+        }
+        return;
+      }
+
+      let token: string | undefined;
+      try {
+        const data = (await response.json()) as AuthResponse;
+        token = data?.token;
+      } catch (error) {
+        console.error("Failed to parse /auth/register response", error);
+      }
+
+      if (!token) {
+        try {
+          const loginResult = await attemptLogin(trimmedEmail, password);
+          if (!loginResult.response.ok) {
+            if (loginResult.response.status === 401) {
+              showToast("注册成功，但自动登录失败，请稍后重试。", "error");
+            } else {
+              showToast(`自动登录失败（${loginResult.response.status}）`, "error");
+            }
+            return;
+          }
+
+          token = loginResult.token;
+        } catch (error) {
+          console.error("Automatic login failed", error);
+          showToast("注册成功，但自动登录时发生错误，请尝试手动登录。", "error");
+          return;
+        }
+      }
+
+      if (!token) {
+        showToast("注册成功，但未获取到访问令牌，请尝试手动登录。", "error");
+        return;
+      }
+
+      setToken(token);
+
+      try {
+        await apiFetch("/me", { cache: "no-store" });
+      } catch (error) {
+        console.warn("Failed to fetch /me after register", error);
+      }
+
+      redirecting = true;
+      router.replace("/dashboard");
+    } catch (error) {
+      console.error("Register request failed", error);
+      showToast("无法连接到服务器，请稍后再试", "error");
+    } finally {
+      if (!redirecting) {
+        setIsSubmitting(false);
+      }
+    }
+  };
+
+  const apiBaseUrl = getApiBaseUrl();
+  const toastElement = toast ? (
+    <Toast
+      key={toast.id}
+      open
+      message={toast.message}
+      variant={toast.variant}
+      onOpenChange={(open) => {
+        if (!open) {
+          setToast(null);
+        }
+      }}
+    />
+  ) : null;
+
+  if (checkingSession) {
+    return (
+      <FormLayout>
+        {toastElement}
+        <FormCard title="请稍候" description="正在验证当前会话…">
+          <p>我们正在确认您的登录状态，请稍后。</p>
+        </FormCard>
+      </FormLayout>
+    );
+  }
+
+  return (
+    <FormLayout>
+      {toastElement}
+      <FormRoot
+        title="注册 DNA Web"
+        description={
+          <>
+            创建一个新账户以访问控制台。
+            <br />
+            当前 API 地址：{apiBaseUrl || "未配置"}
+          </>
+        }
+        footer={
+          <>
+            已有账号？ <FormLink href="/login">立即登录</FormLink>
+          </>
+        }
+        onSubmit={handleSubmit}
+      >
+        <FormField
+          label="邮箱"
+          name="email"
+          type="email"
+          autoComplete="email"
+          placeholder="name@example.com"
+          value={email}
+          onChange={(event) => {
+            setEmail(event.target.value);
+            if (fieldErrors.email) {
+              setFieldErrors((prev) => ({ ...prev, email: undefined }));
+            }
+          }}
+          error={fieldErrors.email}
+        />
+        <FormField
+          label="密码"
+          name="password"
+          type="password"
+          autoComplete="new-password"
+          placeholder="至少 6 位"
+          value={password}
+          onChange={(event) => {
+            setPassword(event.target.value);
+            if (fieldErrors.password) {
+              setFieldErrors((prev) => ({ ...prev, password: undefined }));
+            }
+          }}
+          error={fieldErrors.password}
+        />
+        <FormButton disabled={isSubmitting}>
+          {isSubmitting ? "注册中…" : "注册"}
+        </FormButton>
+      </FormRoot>
+    </FormLayout>
+  );
+}

--- a/src/components/ui/Form.tsx
+++ b/src/components/ui/Form.tsx
@@ -1,0 +1,312 @@
+"use client";
+
+import Link from "next/link";
+import {
+  ComponentPropsWithoutRef,
+  CSSProperties,
+  ReactNode,
+  forwardRef,
+  useEffect,
+  useId,
+} from "react";
+
+const layoutStyle: CSSProperties = {
+  minHeight: "100vh",
+  width: "100%",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  padding: "2.5rem 1.5rem",
+  background: "linear-gradient(135deg, #0f172a 0%, #1f2937 100%)",
+  color: "#f8fafc",
+};
+
+const panelStyle: CSSProperties = {
+  width: "100%",
+  maxWidth: "420px",
+  borderRadius: "18px",
+  padding: "2.5rem",
+  background: "rgba(15, 23, 42, 0.68)",
+  color: "inherit",
+  boxShadow: "0 24px 60px rgba(15, 23, 42, 0.35)",
+  border: "1px solid rgba(148, 163, 184, 0.25)",
+  backdropFilter: "blur(14px)",
+};
+
+const headerStyle: CSSProperties = {
+  marginBottom: "1.75rem",
+};
+
+const titleStyle: CSSProperties = {
+  fontSize: "2.1rem",
+  fontWeight: 700,
+  marginBottom: "0.75rem",
+};
+
+const descriptionStyle: CSSProperties = {
+  opacity: 0.78,
+  lineHeight: 1.6,
+  fontSize: "0.98rem",
+};
+
+const footerStyle: CSSProperties = {
+  marginTop: "2rem",
+  fontSize: "0.95rem",
+  textAlign: "center",
+  opacity: 0.85,
+};
+
+type CardShellProps = {
+  title: string;
+  description?: ReactNode;
+  footer?: ReactNode;
+  children?: ReactNode;
+};
+
+function CardShell({ title, description, footer, children }: CardShellProps) {
+  return (
+    <section style={panelStyle}>
+      <header style={headerStyle}>
+        <h1 style={titleStyle}>{title}</h1>
+        {description ? <p style={descriptionStyle}>{description}</p> : null}
+      </header>
+      {children}
+      {footer ? <footer style={footerStyle}>{footer}</footer> : null}
+    </section>
+  );
+}
+
+export function FormLayout({ children }: { children: ReactNode }) {
+  return <main style={layoutStyle}>{children}</main>;
+}
+
+type FormRootProps = ComponentPropsWithoutRef<"form"> & CardShellProps;
+
+export function FormRoot({
+  title,
+  description,
+  footer,
+  children,
+  noValidate,
+  ...rest
+}: FormRootProps) {
+  return (
+    <CardShell title={title} description={description} footer={footer}>
+      <form
+        {...rest}
+        noValidate={noValidate ?? true}
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: "1.25rem",
+        }}
+      >
+        {children}
+      </form>
+    </CardShell>
+  );
+}
+
+type FormCardProps = CardShellProps;
+
+export function FormCard({ title, description, footer, children }: FormCardProps) {
+  return (
+    <CardShell title={title} description={description} footer={footer}>
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: "1rem",
+          textAlign: "center",
+          fontSize: "0.95rem",
+          lineHeight: 1.6,
+          opacity: 0.85,
+        }}
+      >
+        {children}
+      </div>
+    </CardShell>
+  );
+}
+
+type FormFieldProps = ComponentPropsWithoutRef<"input"> & {
+  label: string;
+  error?: string;
+};
+
+export const FormField = forwardRef<HTMLInputElement, FormFieldProps>(
+  function FormField({ label, id, error, style, ...props }, ref) {
+    const generatedId = useId();
+    const sanitizedLabel = label
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/(^-|-$)+/g, "");
+    const inputId =
+      id ?? props.name ?? (sanitizedLabel.length > 0 ? sanitizedLabel : generatedId);
+
+    return (
+      <label htmlFor={inputId} style={{ display: "block" }}>
+        <span
+          style={{
+            display: "block",
+            fontWeight: 600,
+            fontSize: "0.95rem",
+            marginBottom: "0.55rem",
+          }}
+        >
+          {label}
+        </span>
+        <input
+          {...props}
+          id={inputId}
+          ref={ref}
+          style={{
+            width: "100%",
+            padding: "0.875rem 1rem",
+            borderRadius: "12px",
+            border: `1px solid ${error ? "rgba(239, 68, 68, 0.85)" : "rgba(148, 163, 184, 0.45)"}`,
+            background: "rgba(15, 23, 42, 0.35)",
+            color: "#f8fafc",
+            fontSize: "1rem",
+            outline: "none",
+            transition: "border-color 0.2s ease, box-shadow 0.2s ease",
+            ...style,
+          }}
+        />
+        {error ? (
+          <span
+            style={{
+              display: "block",
+              color: "#f97316",
+              fontSize: "0.85rem",
+              marginTop: "0.5rem",
+            }}
+          >
+            {error}
+          </span>
+        ) : null}
+      </label>
+    );
+  },
+);
+
+type FormButtonProps = ComponentPropsWithoutRef<"button"> & {
+  fullWidth?: boolean;
+};
+
+export function FormButton({
+  fullWidth = true,
+  style,
+  children,
+  type = "submit",
+  ...props
+}: FormButtonProps) {
+  return (
+    <button
+      {...props}
+      type={type}
+      style={{
+        width: fullWidth ? "100%" : undefined,
+        padding: "0.9rem 1rem",
+        borderRadius: "12px",
+        border: "none",
+        background: "#2563eb",
+        color: "#ffffff",
+        fontWeight: 600,
+        fontSize: "1rem",
+        cursor: props.disabled ? "not-allowed" : "pointer",
+        opacity: props.disabled ? 0.72 : 1,
+        transition: "transform 0.2s ease, opacity 0.2s ease",
+        ...style,
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+
+type FormLinkProps = {
+  href: string;
+  children: ReactNode;
+};
+
+export function FormLink({ href, children }: FormLinkProps) {
+  return (
+    <Link
+      href={href}
+      style={{
+        color: "#60a5fa",
+        fontWeight: 600,
+        textDecoration: "none",
+      }}
+    >
+      {children}
+    </Link>
+  );
+}
+
+export type ToastVariant = "default" | "error" | "success";
+
+type ToastProps = {
+  open: boolean;
+  message: string;
+  variant?: ToastVariant;
+  onOpenChange?: (open: boolean) => void;
+  duration?: number;
+};
+
+export function Toast({
+  open,
+  message,
+  variant = "default",
+  onOpenChange,
+  duration = 4000,
+}: ToastProps) {
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    const timer = window.setTimeout(() => {
+      onOpenChange?.(false);
+    }, duration);
+
+    return () => {
+      window.clearTimeout(timer);
+    };
+  }, [open, duration, onOpenChange, message, variant]);
+
+  if (!open) {
+    return null;
+  }
+
+  const background =
+    variant === "error"
+      ? "rgba(239, 68, 68, 0.95)"
+      : variant === "success"
+      ? "rgba(34, 197, 94, 0.95)"
+      : "rgba(37, 99, 235, 0.95)";
+
+  return (
+    <div
+      role="status"
+      aria-live="assertive"
+      style={{
+        position: "fixed",
+        top: "2rem",
+        right: "2rem",
+        maxWidth: "320px",
+        padding: "1rem 1.25rem",
+        borderRadius: "12px",
+        background,
+        color: "#ffffff",
+        boxShadow: "0 24px 60px rgba(15, 23, 42, 0.35)",
+        fontSize: "0.95rem",
+        lineHeight: 1.5,
+        zIndex: 1000,
+      }}
+    >
+      {message}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable form layout, field, button, link, and toast components for the auth experience
- implement the login page with validation, API integration, session checking, and dashboard redirect on success
- implement the register page with validation, automatic login fallback, /me verification, and toast messaging for conflicts and other errors

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce134160a88330b1d74fcc8de0962a