### PR TITLE
feat: add monster lab list and detail pages

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,20 +1,21 @@
 "use client";
 
-import {
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-  type CSSProperties,
-} from "react";
+import { useCallback, useEffect, useRef, useState, type CSSProperties } from "react";
 import { useRouter } from "next/navigation";
 import { apiFetch, getApiBaseUrl } from "@/lib/api";
 import { clearToken, getToken } from "@/lib/auth";
 
-type HealthState = "checking" | "ok" | "error";
-
-type HealthResponse = {
-  ok?: boolean;
+type WalletData = {
+  balance?: number | string;
+  available?: number | string;
+  total?: number | string;
+  amount?: number | string;
+  currency?: string | null;
+  symbol?: string | null;
+  unit?: string | null;
+  address?: string | null;
+  walletAddress?: string | null;
+  [key: string]: unknown;
 };
 
 const containerStyle: CSSProperties = {
@@ -23,43 +24,190 @@ const containerStyle: CSSProperties = {
   display: "flex",
   alignItems: "center",
   justifyContent: "center",
-  padding: "2rem",
+  padding: "2.5rem 1.5rem",
   background: "linear-gradient(135deg, #0f172a 0%, #1f2937 100%)",
   color: "#f8fafc",
 };
 
 const cardStyle: CSSProperties = {
   width: "100%",
-  maxWidth: "640px",
-  borderRadius: "18px",
-  padding: "2.5rem",
-  background: "rgba(15, 23, 42, 0.45)",
+  maxWidth: "720px",
+  borderRadius: "20px",
+  padding: "3rem",
+  background: "rgba(15, 23, 42, 0.6)",
   color: "inherit",
-  boxShadow: "0 24px 60px rgba(15, 23, 42, 0.3)",
-  backdropFilter: "blur(14px)",
-  border: "1px solid rgba(148, 163, 184, 0.25)",
+  boxShadow: "0 28px 65px rgba(15, 23, 42, 0.35)",
+  border: "1px solid rgba(148, 163, 184, 0.28)",
+  backdropFilter: "blur(16px)",
+  display: "flex",
+  flexDirection: "column",
+  gap: "2.25rem",
+};
+
+const walletPanelStyle: CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: "1.25rem",
+  background: "rgba(15, 23, 42, 0.45)",
+  border: "1px solid rgba(148, 163, 184, 0.22)",
+  borderRadius: "16px",
+  padding: "1.5rem",
+};
+
+const balanceStyle: CSSProperties = {
+  fontSize: "2.4rem",
+  fontWeight: 700,
+  lineHeight: 1.2,
+};
+
+const balanceMetaStyle: CSSProperties = {
+  display: "flex",
+  flexWrap: "wrap",
+  gap: "0.75rem",
+  fontSize: "0.95rem",
+  opacity: 0.8,
+};
+
+const sectionTitleStyle: CSSProperties = {
+  fontSize: "0.9rem",
+  fontWeight: 600,
+  letterSpacing: "0.08em",
+  textTransform: "uppercase",
+  opacity: 0.7,
+};
+
+const errorStyle: CSSProperties = {
+  padding: "1rem 1.25rem",
+  borderRadius: "12px",
+  background: "rgba(239, 68, 68, 0.12)",
+  border: "1px solid rgba(248, 113, 113, 0.45)",
+  color: "#fecaca",
+  fontSize: "0.95rem",
+  lineHeight: 1.6,
 };
 
 const buttonRowStyle: CSSProperties = {
   display: "flex",
+  flexWrap: "wrap",
   gap: "1rem",
-  marginTop: "2rem",
 };
 
 const buttonStyle: CSSProperties = {
-  padding: "0.75rem 1.5rem",
+  flex: "1 1 180px",
+  padding: "0.95rem 1.25rem",
   borderRadius: "12px",
   border: "none",
   fontWeight: 600,
+  fontSize: "1rem",
   cursor: "pointer",
-  transition: "opacity 0.2s ease",
+  transition: "transform 0.2s ease, opacity 0.2s ease",
 };
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === "object" && !Array.isArray(value);
+}
+
+function toMaybeNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return null;
+    }
+
+    const parsed = Number(trimmed);
+    if (!Number.isNaN(parsed)) {
+      return parsed;
+    }
+  }
+
+  return null;
+}
+
+function toMaybeString(value: unknown): string | null {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+
+  return null;
+}
+
+function normalizeWallet(payload: unknown): WalletData {
+  if (isPlainObject(payload)) {
+    if (payload.wallet && isPlainObject(payload.wallet)) {
+      return payload.wallet as WalletData;
+    }
+
+    return payload as WalletData;
+  }
+
+  return { balance: payload as number | string };
+}
+
+function pickBalanceValue(wallet: WalletData): unknown {
+  if (wallet.balance != null) {
+    return wallet.balance;
+  }
+
+  if (wallet.available != null) {
+    return wallet.available;
+  }
+
+  if (wallet.total != null) {
+    return wallet.total;
+  }
+
+  if (wallet.amount != null) {
+    return wallet.amount;
+  }
+
+  return null;
+}
+
+function formatBalance(wallet: WalletData): string {
+  const candidate = pickBalanceValue(wallet);
+  const numeric = toMaybeNumber(candidate);
+  if (numeric != null) {
+    return numeric.toLocaleString("zh-CN", { maximumFractionDigits: 2 });
+  }
+
+  const text = toMaybeString(candidate);
+  if (text) {
+    return text;
+  }
+
+  return "--";
+}
+
+function resolveCurrency(wallet: WalletData): string | null {
+  const currency =
+    toMaybeString(wallet.currency) ??
+    toMaybeString(wallet.symbol) ??
+    toMaybeString(wallet.unit);
+
+  return currency ?? null;
+}
+
+function resolveAddress(wallet: WalletData): string | null {
+  const address =
+    toMaybeString(wallet.address) ?? toMaybeString(wallet.walletAddress);
+  return address ?? null;
+}
 
 export default function DashboardPage() {
   const router = useRouter();
-  const [state, setState] = useState<HealthState>("checking");
-  const [message, setMessage] = useState("正在检测 API 状态…");
-  const mountedRef = useRef(true);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [wallet, setWallet] = useState<WalletData | null>(null);
+  const mountedRef = useRef(false);
 
   useEffect(() => {
     mountedRef.current = true;
@@ -68,41 +216,40 @@ export default function DashboardPage() {
     };
   }, []);
 
-  const updateState = useCallback((nextState: HealthState, nextMessage: string) => {
+  const fetchWallet = useCallback(async () => {
     if (!mountedRef.current) {
       return;
     }
 
-    setState(nextState);
-    setMessage(nextMessage);
-  }, []);
+    setIsLoading(true);
+    setError(null);
 
-  const runHealthCheck = useCallback(async () => {
-    updateState("checking", "正在检测 API 状态…");
     try {
-      const response = await apiFetch("/health", { cache: "no-store" });
-
+      const response = await apiFetch("/wallet", { cache: "no-store" });
       if (!response.ok) {
-        updateState("error", `API 返回状态码 ${response.status}`);
+        throw new Error(`Request failed with status ${response.status}`);
+      }
+
+      const data = normalizeWallet(await response.json());
+      if (!mountedRef.current) {
         return;
       }
 
-      try {
-        const data = (await response.json()) as HealthResponse;
-        if (data?.ok) {
-          updateState("ok", "API 连接正常，欢迎回来！");
-        } else {
-          updateState("error", "API 返回了意料之外的响应");
-        }
-      } catch (error) {
-        console.error("Failed to parse /health response", error);
-        updateState("error", "无法解析 API 响应");
+      setWallet(data);
+    } catch (err) {
+      console.error("Failed to fetch wallet", err);
+      if (!mountedRef.current) {
+        return;
       }
-    } catch (error) {
-      console.error("Unable to reach API", error);
-      updateState("error", "无法连接到 API，请稍后再试");
+
+      setWallet(null);
+      setError("无法获取钱包信息，请稍后重试。");
+    } finally {
+      if (mountedRef.current) {
+        setIsLoading(false);
+      }
     }
-  }, [updateState]);
+  }, []);
 
   useEffect(() => {
     const token = getToken();
@@ -111,50 +258,100 @@ export default function DashboardPage() {
       return;
     }
 
-    void runHealthCheck();
-  }, [router, runHealthCheck]);
+    void fetchWallet();
+  }, [router, fetchWallet]);
 
   const handleLogout = () => {
     clearToken();
     router.replace("/");
   };
 
+  const handleOpenLab = () => {
+    router.push("/lab");
+  };
+
   const apiBaseUrl = getApiBaseUrl();
+  const balanceLabel = wallet ? formatBalance(wallet) : "--";
+  const currencyLabel = wallet ? resolveCurrency(wallet) : null;
+  const addressLabel = wallet ? resolveAddress(wallet) : null;
 
   return (
     <main style={containerStyle}>
       <section style={cardStyle}>
-        <header style={{ marginBottom: "1.5rem" }}>
-          <h1 style={{ fontSize: "2.25rem", fontWeight: 700, marginBottom: "0.75rem" }}>
-            控制台
-          </h1>
-          <p style={{ opacity: 0.75, lineHeight: 1.6 }}>
+        <header style={{ display: "flex", flexDirection: "column", gap: "0.75rem" }}>
+          <h1 style={{ fontSize: "2.4rem", fontWeight: 700 }}>欢迎回到 DNA 控制台</h1>
+          <p style={{ opacity: 0.75, lineHeight: 1.6, fontSize: "1rem" }}>
             当前 API 地址：{apiBaseUrl || "未配置"}
             <br />
-            状态：{state === "checking" ? "检测中" : state === "ok" ? "正常" : "异常"}
+            在这里查看您的钱包余额并前往怪兽实验室。
           </p>
         </header>
-        <p style={{ lineHeight: 1.7 }}>{message}</p>
+
+        <section style={walletPanelStyle}>
+          <div>
+            <span style={{ ...sectionTitleStyle, display: "block", marginBottom: "0.4rem" }}>
+              钱包余额
+            </span>
+            <div style={balanceStyle}>
+              {balanceLabel}
+              {currencyLabel ? (
+                <span style={{ fontSize: "1.1rem", marginLeft: "0.65rem", opacity: 0.8 }}>
+                  {currencyLabel}
+                </span>
+              ) : null}
+            </div>
+          </div>
+
+          {addressLabel ? (
+            <div style={balanceMetaStyle}>
+              <span>钱包地址：{addressLabel}</span>
+            </div>
+          ) : null}
+
+          {isLoading ? (
+            <p style={{ opacity: 0.7 }}>正在获取钱包信息…</p>
+          ) : error ? (
+            <div style={errorStyle}>{error}</div>
+          ) : null}
+        </section>
+
         <div style={buttonRowStyle}>
           <button
             type="button"
-            disabled={state === "checking"}
             style={{
               ...buttonStyle,
-              background: "#1d4ed8",
-              color: "white",
-              opacity: state === "checking" ? 0.6 : 1,
-              cursor: state === "checking" ? "wait" : "pointer",
+              background: "rgba(59, 130, 246, 0.18)",
+              color: "#bfdbfe",
+              opacity: isLoading ? 0.65 : 1,
+              cursor: isLoading ? "wait" : "pointer",
             }}
             onClick={() => {
-              void runHealthCheck();
+              if (!isLoading) {
+                void fetchWallet();
+              }
             }}
+            disabled={isLoading}
           >
-            刷新状态
+            刷新钱包
           </button>
           <button
             type="button"
-            style={{ ...buttonStyle, background: "rgba(255, 255, 255, 0.08)", color: "inherit" }}
+            style={{
+              ...buttonStyle,
+              background: "#2563eb",
+              color: "#ffffff",
+            }}
+            onClick={handleOpenLab}
+          >
+            前往怪兽实验室
+          </button>
+          <button
+            type="button"
+            style={{
+              ...buttonStyle,
+              background: "rgba(255, 255, 255, 0.08)",
+              color: "inherit",
+            }}
             onClick={handleLogout}
           >
             退出登录

--- a/src/app/lab/monster/[id]/page.tsx
+++ b/src/app/lab/monster/[id]/page.tsx
@@ -1,0 +1,360 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+} from "react";
+import Link from "next/link";
+import { useParams, useRouter } from "next/navigation";
+import MonsterCard from "@/components/MonsterCard";
+import { apiFetch } from "@/lib/api";
+import { getToken } from "@/lib/auth";
+import { MonsterRecord, normalizeMonster } from "@/lib/monsters";
+
+const layoutStyle: CSSProperties = {
+  minHeight: "100vh",
+  width: "100%",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  padding: "2.5rem 1.5rem",
+  background: "linear-gradient(135deg, #0f172a 0%, #1f2937 100%)",
+  color: "#f8fafc",
+};
+
+const contentStyle: CSSProperties = {
+  width: "100%",
+  maxWidth: "980px",
+  borderRadius: "24px",
+  padding: "3rem",
+  background: "rgba(15, 23, 42, 0.62)",
+  border: "1px solid rgba(148, 163, 184, 0.28)",
+  boxShadow: "0 32px 70px rgba(15, 23, 42, 0.35)",
+  backdropFilter: "blur(18px)",
+  display: "flex",
+  flexDirection: "column",
+  gap: "2.25rem",
+};
+
+const actionRowStyle: CSSProperties = {
+  display: "flex",
+  flexWrap: "wrap",
+  alignItems: "center",
+  justifyContent: "space-between",
+  gap: "1rem",
+};
+
+const backLinkStyle: CSSProperties = {
+  color: "#93c5fd",
+  textDecoration: "none",
+  fontWeight: 600,
+  display: "inline-flex",
+  alignItems: "center",
+  gap: "0.35rem",
+};
+
+const refreshButtonStyle: CSSProperties = {
+  padding: "0.8rem 1.35rem",
+  borderRadius: "12px",
+  border: "1px solid rgba(148, 163, 184, 0.35)",
+  background: "rgba(59, 130, 246, 0.18)",
+  color: "#bfdbfe",
+  fontWeight: 600,
+  fontSize: "0.95rem",
+  cursor: "pointer",
+  transition: "opacity 0.2s ease, transform 0.2s ease",
+};
+
+const sectionTitleStyle: CSSProperties = {
+  fontSize: "0.92rem",
+  fontWeight: 600,
+  textTransform: "uppercase",
+  letterSpacing: "0.08em",
+  opacity: 0.72,
+};
+
+const loadingStyle: CSSProperties = {
+  fontSize: "0.95rem",
+  opacity: 0.75,
+};
+
+const errorStyle: CSSProperties = {
+  padding: "1rem 1.25rem",
+  borderRadius: "12px",
+  background: "rgba(239, 68, 68, 0.12)",
+  border: "1px solid rgba(248, 113, 113, 0.42)",
+  color: "#fecaca",
+  fontSize: "0.95rem",
+  lineHeight: 1.6,
+};
+
+const descriptionBoxStyle: CSSProperties = {
+  borderRadius: "18px",
+  border: "1px solid rgba(148, 163, 184, 0.25)",
+  background: "rgba(15, 23, 42, 0.45)",
+  padding: "1.5rem",
+  fontSize: "0.98rem",
+  lineHeight: 1.7,
+  opacity: 0.88,
+};
+
+const metadataGridStyle: CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
+  gap: "1.15rem",
+};
+
+const metadataItemStyle: CSSProperties = {
+  borderRadius: "16px",
+  border: "1px solid rgba(148, 163, 184, 0.25)",
+  background: "rgba(15, 23, 42, 0.45)",
+  padding: "1.1rem 1.25rem",
+  display: "flex",
+  flexDirection: "column",
+  gap: "0.35rem",
+};
+
+const metadataLabelStyle: CSSProperties = {
+  fontSize: "0.78rem",
+  letterSpacing: "0.06em",
+  textTransform: "uppercase",
+  opacity: 0.65,
+};
+
+const metadataValueStyle: CSSProperties = {
+  fontSize: "1.08rem",
+  fontWeight: 600,
+  lineHeight: 1.4,
+};
+
+type DetailRow = {
+  label: string;
+  value: string;
+};
+
+function formatMaybeString(value: unknown): string | null {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+
+  return null;
+}
+
+function formatNumber(value: unknown): string | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value.toLocaleString("zh-CN", { maximumFractionDigits: 2 });
+  }
+
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+
+  return null;
+}
+
+function formatLevel(value: unknown): string | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return `Lv. ${value}`;
+  }
+
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed.length === 0) {
+      return null;
+    }
+    return trimmed.startsWith("Lv.") ? trimmed : `Lv. ${trimmed}`;
+  }
+
+  return null;
+}
+
+function buildDetailRows(monster: MonsterRecord): DetailRow[] {
+  const rows: DetailRow[] = [];
+
+  const pushRow = (label: string, value: string | null) => {
+    if (value) {
+      rows.push({ label, value });
+    }
+  };
+
+  pushRow("编号", `#${String(monster.id)}`);
+  pushRow("名称", formatMaybeString(monster.name ?? monster.nickname));
+  pushRow("物种", formatMaybeString(monster.species));
+  pushRow("稀有度", formatMaybeString(monster.rarity));
+  pushRow("等级", formatLevel(monster.level));
+  pushRow("能量", formatNumber(monster.energy));
+  pushRow("经验", formatNumber(monster.experience));
+  pushRow("世代", formatNumber(monster.generation));
+  pushRow("状态", formatMaybeString(monster.status));
+  pushRow("拥有者", formatMaybeString(monster.owner));
+  pushRow("创建时间", formatMaybeString(monster.createdAt));
+  pushRow("更新时间", formatMaybeString(monster.updatedAt));
+
+  return rows;
+}
+
+export default function MonsterDetailPage() {
+  const router = useRouter();
+  const params = useParams<{ id: string }>();
+  const rawId = params?.id;
+  const monsterId = Array.isArray(rawId) ? rawId[0] : rawId;
+
+  const [monster, setMonster] = useState<MonsterRecord | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const mountedRef = useRef(false);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const fetchMonster = useCallback(async () => {
+    if (!mountedRef.current) {
+      return;
+    }
+
+    if (!monsterId) {
+      setMonster(null);
+      setError("无法识别怪兽编号。");
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const response = await apiFetch(`/monsters/${encodeURIComponent(monsterId)}`, {
+        cache: "no-store",
+      });
+
+      if (response.status === 404) {
+        if (mountedRef.current) {
+          setMonster(null);
+          setError("未找到对应的怪兽。");
+        }
+        return;
+      }
+
+      if (!response.ok) {
+        throw new Error(`Request failed with status ${response.status}`);
+      }
+
+      let payload: unknown = null;
+      if (response.status !== 204) {
+        payload = await response.json();
+      }
+
+      if (!mountedRef.current) {
+        return;
+      }
+
+      const normalized = normalizeMonster(payload, String(monsterId));
+      if (!normalized) {
+        throw new Error("Unexpected monster payload");
+      }
+
+      setMonster(normalized);
+    } catch (err) {
+      console.error("Failed to fetch monster detail", err);
+      if (!mountedRef.current) {
+        return;
+      }
+
+      setMonster(null);
+      setError("无法加载怪兽详情，请稍后重试。");
+    } finally {
+      if (mountedRef.current) {
+        setIsLoading(false);
+      }
+    }
+  }, [monsterId]);
+
+  useEffect(() => {
+    const token = getToken();
+    if (!token) {
+      router.replace("/");
+      return;
+    }
+
+    void fetchMonster();
+  }, [router, fetchMonster]);
+
+  const detailRows = monster ? buildDetailRows(monster) : [];
+  const descriptionText = monster ? formatMaybeString(monster.description) : null;
+
+  return (
+    <main style={layoutStyle}>
+      <section style={contentStyle}>
+        <div style={actionRowStyle}>
+          <Link href="/lab" style={backLinkStyle}>
+            <span aria-hidden="true">←</span>
+            返回怪兽实验室
+          </Link>
+          <button
+            type="button"
+            style={{
+              ...refreshButtonStyle,
+              opacity: isLoading ? 0.65 : 1,
+              cursor: isLoading ? "wait" : "pointer",
+            }}
+            onClick={() => {
+              if (!isLoading) {
+                void fetchMonster();
+              }
+            }}
+            disabled={isLoading}
+          >
+            刷新详情
+          </button>
+        </div>
+
+        {error ? <div style={errorStyle}>{error}</div> : null}
+        {isLoading ? <p style={loadingStyle}>正在加载怪兽详情…</p> : null}
+
+        {monster ? (
+          <div style={{ display: "flex", flexDirection: "column", gap: "2rem" }}>
+            <MonsterCard monster={monster} highlight />
+
+            {descriptionText ? (
+              <section style={{ display: "flex", flexDirection: "column", gap: "0.6rem" }}>
+                <h2 style={sectionTitleStyle}>怪兽描述</h2>
+                <div style={descriptionBoxStyle}>{descriptionText}</div>
+              </section>
+            ) : null}
+
+            {detailRows.length > 0 ? (
+              <section style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+                <h2 style={sectionTitleStyle}>基础信息</h2>
+                <div style={metadataGridStyle}>
+                  {detailRows.map((row) => (
+                    <div key={row.label} style={metadataItemStyle}>
+                      <span style={metadataLabelStyle}>{row.label}</span>
+                      <span style={metadataValueStyle}>{row.value}</span>
+                    </div>
+                  ))}
+                </div>
+              </section>
+            ) : null}
+          </div>
+        ) : null}
+
+        {!monster && !isLoading && !error ? (
+          <p style={loadingStyle}>未能找到怪兽数据。</p>
+        ) : null}
+      </section>
+    </main>
+  );
+}

--- a/src/app/lab/page.tsx
+++ b/src/app/lab/page.tsx
@@ -1,0 +1,340 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState, type CSSProperties } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import MonsterCard from "@/components/MonsterCard";
+import { apiFetch } from "@/lib/api";
+import { getToken } from "@/lib/auth";
+import { MonsterRecord, parseMonsterList } from "@/lib/monsters";
+
+const layoutStyle: CSSProperties = {
+  minHeight: "100vh",
+  width: "100%",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  padding: "2.5rem 1.5rem",
+  background: "linear-gradient(135deg, #0f172a 0%, #1f2937 100%)",
+  color: "#f8fafc",
+};
+
+const contentStyle: CSSProperties = {
+  width: "100%",
+  maxWidth: "1100px",
+  borderRadius: "22px",
+  padding: "3rem",
+  background: "rgba(15, 23, 42, 0.62)",
+  border: "1px solid rgba(148, 163, 184, 0.25)",
+  boxShadow: "0 32px 70px rgba(15, 23, 42, 0.35)",
+  backdropFilter: "blur(16px)",
+  display: "flex",
+  flexDirection: "column",
+  gap: "2rem",
+};
+
+const headerStyle: CSSProperties = {
+  display: "flex",
+  flexWrap: "wrap",
+  alignItems: "center",
+  justifyContent: "space-between",
+  gap: "1.25rem",
+};
+
+const headingStyle: CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: "0.6rem",
+};
+
+const titleStyle: CSSProperties = {
+  fontSize: "2.2rem",
+  fontWeight: 700,
+};
+
+const descriptionStyle: CSSProperties = {
+  opacity: 0.78,
+  fontSize: "1rem",
+  lineHeight: 1.6,
+  maxWidth: "640px",
+};
+
+const refreshButtonStyle: CSSProperties = {
+  padding: "0.85rem 1.4rem",
+  borderRadius: "12px",
+  border: "1px solid rgba(148, 163, 184, 0.35)",
+  background: "rgba(59, 130, 246, 0.15)",
+  color: "#bfdbfe",
+  fontWeight: 600,
+  fontSize: "0.95rem",
+  cursor: "pointer",
+  transition: "opacity 0.2s ease, transform 0.2s ease",
+};
+
+const gridStyle: CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "repeat(auto-fit, minmax(260px, 1fr))",
+  gap: "1.75rem",
+};
+
+const loadingStyle: CSSProperties = {
+  fontSize: "0.95rem",
+  opacity: 0.75,
+};
+
+const messageBoxStyle: CSSProperties = {
+  padding: "1rem 1.25rem",
+  borderRadius: "12px",
+  fontSize: "0.95rem",
+  lineHeight: 1.6,
+};
+
+const successMessageStyle: CSSProperties = {
+  ...messageBoxStyle,
+  background: "rgba(34, 197, 94, 0.12)",
+  border: "1px solid rgba(134, 239, 172, 0.35)",
+  color: "#bbf7d0",
+};
+
+const errorMessageStyle: CSSProperties = {
+  ...messageBoxStyle,
+  background: "rgba(239, 68, 68, 0.12)",
+  border: "1px solid rgba(248, 113, 113, 0.4)",
+  color: "#fecaca",
+};
+
+const emptyStateStyle: CSSProperties = {
+  borderRadius: "18px",
+  border: "1px solid rgba(148, 163, 184, 0.25)",
+  background: "rgba(15, 23, 42, 0.45)",
+  padding: "3rem 1.5rem",
+  display: "flex",
+  flexDirection: "column",
+  gap: "1.25rem",
+  alignItems: "center",
+  textAlign: "center",
+};
+
+const emptyTitleStyle: CSSProperties = {
+  fontSize: "1.35rem",
+  fontWeight: 600,
+};
+
+const emptyDescriptionStyle: CSSProperties = {
+  fontSize: "0.95rem",
+  opacity: 0.75,
+  maxWidth: "420px",
+};
+
+const claimButtonStyle: CSSProperties = {
+  padding: "0.9rem 1.6rem",
+  borderRadius: "12px",
+  border: "none",
+  background: "#2563eb",
+  color: "#ffffff",
+  fontWeight: 600,
+  fontSize: "1rem",
+  cursor: "pointer",
+  transition: "opacity 0.2s ease, transform 0.2s ease",
+};
+
+const cardLinkStyle: CSSProperties = {
+  textDecoration: "none",
+  color: "inherit",
+  display: "block",
+  height: "100%",
+};
+
+const cardFooterStyle: CSSProperties = {
+  fontSize: "0.9rem",
+  opacity: 0.7,
+  display: "flex",
+  alignItems: "center",
+  gap: "0.35rem",
+};
+
+type FetchOptions = {
+  preserveSuccess?: boolean;
+};
+
+export default function LabPage() {
+  const router = useRouter();
+  const [monsters, setMonsters] = useState<MonsterRecord[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isClaiming, setIsClaiming] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const mountedRef = useRef(false);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const fetchMonsters = useCallback(
+    async (options?: FetchOptions) => {
+      if (!mountedRef.current) {
+        return;
+      }
+
+      setIsLoading(true);
+      setError(null);
+      if (!options?.preserveSuccess) {
+        setSuccessMessage(null);
+      }
+
+      try {
+        const response = await apiFetch("/monsters/my", { cache: "no-store" });
+        if (!response.ok) {
+          throw new Error(`Request failed with status ${response.status}`);
+        }
+
+        let payload: unknown = [];
+        if (response.status !== 204) {
+          payload = await response.json();
+        }
+
+        if (!mountedRef.current) {
+          return;
+        }
+
+        const list = parseMonsterList(payload);
+        setMonsters(list);
+      } catch (err) {
+        console.error("Failed to fetch monsters", err);
+        if (!mountedRef.current) {
+          return;
+        }
+
+        setError("无法获取怪兽列表，请稍后重试。");
+      } finally {
+        if (mountedRef.current) {
+          setIsLoading(false);
+        }
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    const token = getToken();
+    if (!token) {
+      router.replace("/");
+      return;
+    }
+
+    void fetchMonsters();
+  }, [router, fetchMonsters]);
+
+  const handleClaimStarter = useCallback(async () => {
+    if (isClaiming) {
+      return;
+    }
+
+    setIsClaiming(true);
+    setError(null);
+    setSuccessMessage(null);
+
+    try {
+      const response = await apiFetch("/monsters/claim-starter", { method: "POST" });
+      if (!response.ok) {
+        throw new Error(`Claim failed with status ${response.status}`);
+      }
+
+      await fetchMonsters({ preserveSuccess: true });
+      if (mountedRef.current) {
+        setSuccessMessage("领取成功！新的怪兽已加入队伍。");
+      }
+    } catch (err) {
+      console.error("Failed to claim starter monster", err);
+      if (mountedRef.current) {
+        setError("领取初始怪失败，请稍后再试。");
+      }
+    } finally {
+      if (mountedRef.current) {
+        setIsClaiming(false);
+      }
+    }
+  }, [fetchMonsters, isClaiming]);
+
+  const hasMonsters = monsters.length > 0;
+
+  return (
+    <main style={layoutStyle}>
+      <section style={contentStyle}>
+        <header style={headerStyle}>
+          <div style={headingStyle}>
+            <h1 style={titleStyle}>怪兽实验室</h1>
+            <p style={descriptionStyle}>
+              管理你的怪兽队伍，查看它们的稀有度、等级与基因特征。点击任意怪兽卡片即可查看详细信息。
+            </p>
+          </div>
+          <button
+            type="button"
+            style={{
+              ...refreshButtonStyle,
+              opacity: isLoading || isClaiming ? 0.65 : 1,
+              cursor: isLoading || isClaiming ? "wait" : "pointer",
+            }}
+            onClick={() => {
+              if (!isLoading && !isClaiming) {
+                void fetchMonsters();
+              }
+            }}
+            disabled={isLoading || isClaiming}
+          >
+            刷新列表
+          </button>
+        </header>
+
+        {successMessage ? <div style={successMessageStyle}>{successMessage}</div> : null}
+        {error ? <div style={errorMessageStyle}>{error}</div> : null}
+        {isLoading && !hasMonsters ? <p style={loadingStyle}>正在加载怪兽数据…</p> : null}
+        {isLoading && hasMonsters ? <p style={loadingStyle}>正在刷新怪兽列表…</p> : null}
+
+        {hasMonsters ? (
+          <div style={gridStyle}>
+            {monsters.map((monster) => {
+              const monsterId = encodeURIComponent(String(monster.id));
+              return (
+                <Link key={monsterId} href={`/lab/monster/${monsterId}`} style={cardLinkStyle}>
+                  <MonsterCard
+                    monster={monster}
+                    footer={<div style={cardFooterStyle}>查看详情 →</div>}
+                  />
+                </Link>
+              );
+            })}
+          </div>
+        ) : null}
+
+        {!isLoading && !hasMonsters ? (
+          <div style={emptyStateStyle}>
+            <h2 style={emptyTitleStyle}>你的实验室还没有怪兽</h2>
+            <p style={emptyDescriptionStyle}>
+              领取你的第一只怪兽，开启探索 DNA 宇宙的旅程。初始怪会自动添加到你的队伍中。
+            </p>
+            <button
+              type="button"
+              style={{
+                ...claimButtonStyle,
+                opacity: isClaiming ? 0.7 : 1,
+                cursor: isClaiming ? "wait" : "pointer",
+              }}
+              onClick={() => {
+                if (!isClaiming) {
+                  void handleClaimStarter();
+                }
+              }}
+              disabled={isClaiming}
+            >
+              {isClaiming ? "领取中…" : "领取初始怪"}
+            </button>
+          </div>
+        ) : null}
+      </section>
+    </main>
+  );
+}

--- a/src/components/MonsterCard.tsx
+++ b/src/components/MonsterCard.tsx
@@ -1,0 +1,267 @@
+"use client";
+
+import { CSSProperties, ReactNode } from "react";
+import { MonsterData, MonsterGene } from "@/lib/monsters";
+
+type MonsterCardProps = {
+  monster: MonsterData;
+  footer?: ReactNode;
+  highlight?: boolean;
+};
+
+const cardStyle: CSSProperties = {
+  width: "100%",
+  borderRadius: "18px",
+  padding: "1.75rem",
+  background: "rgba(15, 23, 42, 0.55)",
+  color: "#f8fafc",
+  boxShadow: "0 20px 45px rgba(15, 23, 42, 0.3)",
+  border: "1px solid rgba(148, 163, 184, 0.28)",
+  display: "flex",
+  flexDirection: "column",
+  gap: "1.5rem",
+  height: "100%",
+  transition: "transform 0.2s ease, box-shadow 0.2s ease",
+};
+
+const headerStyle: CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: "0.6rem",
+};
+
+const badgeStyle: CSSProperties = {
+  alignSelf: "flex-start",
+  padding: "0.35rem 0.7rem",
+  borderRadius: "999px",
+  background: "rgba(37, 99, 235, 0.24)",
+  color: "#bfdbfe",
+  fontSize: "0.75rem",
+  fontWeight: 600,
+  letterSpacing: "0.05em",
+  textTransform: "uppercase",
+};
+
+const titleStyle: CSSProperties = {
+  fontSize: "1.6rem",
+  fontWeight: 700,
+  lineHeight: 1.2,
+};
+
+const subtitleStyle: CSSProperties = {
+  fontSize: "0.95rem",
+  opacity: 0.75,
+};
+
+const sectionTitleStyle: CSSProperties = {
+  fontSize: "0.95rem",
+  fontWeight: 600,
+  textTransform: "uppercase",
+  letterSpacing: "0.06em",
+  opacity: 0.75,
+};
+
+const statsGridStyle: CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "repeat(3, minmax(0, 1fr))",
+  gap: "0.85rem",
+};
+
+const statCardStyle: CSSProperties = {
+  borderRadius: "14px",
+  padding: "0.85rem 1rem",
+  background: "rgba(15, 23, 42, 0.45)",
+  border: "1px solid rgba(148, 163, 184, 0.22)",
+  display: "flex",
+  flexDirection: "column",
+  gap: "0.3rem",
+};
+
+const statLabelStyle: CSSProperties = {
+  fontSize: "0.78rem",
+  letterSpacing: "0.05em",
+  textTransform: "uppercase",
+  opacity: 0.6,
+};
+
+const statValueStyle: CSSProperties = {
+  fontSize: "1.15rem",
+  fontWeight: 700,
+};
+
+const geneListStyle: CSSProperties = {
+  display: "flex",
+  flexWrap: "wrap",
+  gap: "0.6rem",
+};
+
+const geneChipStyle: CSSProperties = {
+  padding: "0.45rem 0.85rem",
+  borderRadius: "999px",
+  background: "rgba(59, 130, 246, 0.22)",
+  color: "#dbeafe",
+  fontSize: "0.82rem",
+  fontWeight: 600,
+  letterSpacing: "0.02em",
+  lineHeight: 1.2,
+};
+
+const emptyGeneStyle: CSSProperties = {
+  opacity: 0.65,
+  fontSize: "0.85rem",
+};
+
+function resolveGeneLabel(gene: MonsterGene, index: number): string {
+  if (gene == null) {
+    return `基因 ${index + 1}`;
+  }
+
+  if (typeof gene === "string" || typeof gene === "number") {
+    const label = String(gene).trim();
+    return label.length > 0 ? label : `基因 ${index + 1}`;
+  }
+
+  if (typeof gene === "object") {
+    const labelLikeKeys = ["label", "name", "trait", "title"];
+    for (const key of labelLikeKeys) {
+      const value = gene[key];
+      if (typeof value === "string" && value.trim().length > 0) {
+        return value.trim();
+      }
+    }
+
+    if ("type" in gene) {
+      const typeValue = gene.type;
+      const valueValue = "value" in gene ? gene.value : undefined;
+      if (typeof typeValue === "string" && typeValue.trim().length > 0) {
+        const typeText = typeValue.trim();
+        if (typeof valueValue === "string" && valueValue.trim().length > 0) {
+          return `${typeText}: ${valueValue.trim()}`;
+        }
+        return typeText;
+      }
+    }
+
+    const firstPrimitive = Object.values(gene).find((value) => {
+      if (typeof value === "string") {
+        return value.trim().length > 0;
+      }
+      if (typeof value === "number") {
+        return Number.isFinite(value);
+      }
+      return false;
+    });
+
+    if (typeof firstPrimitive === "string") {
+      return firstPrimitive.trim();
+    }
+    if (typeof firstPrimitive === "number") {
+      return String(firstPrimitive);
+    }
+  }
+
+  return `基因 ${index + 1}`;
+}
+
+function formatNumber(value: unknown): string {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value.toLocaleString("zh-CN", { maximumFractionDigits: 2 });
+  }
+
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed.length > 0) {
+      return trimmed;
+    }
+  }
+
+  return "--";
+}
+
+function formatLevel(level: unknown): string {
+  if (typeof level === "number" && Number.isFinite(level)) {
+    return `Lv. ${level}`;
+  }
+
+  if (typeof level === "string" && level.trim().length > 0) {
+    return level.startsWith("Lv.") ? level : `Lv. ${level.trim()}`;
+  }
+
+  return "未知";
+}
+
+function formatRarity(rarity: unknown): string {
+  if (typeof rarity === "string" && rarity.trim().length > 0) {
+    return rarity.trim();
+  }
+
+  return "未知";
+}
+
+const MonsterCard = ({ monster, footer, highlight = false }: MonsterCardProps) => {
+  const idLabel = `#${monster.id}`;
+  const displayName = monster.name ?? monster.nickname ?? null;
+  const species = monster.species ?? "未知物种";
+  const rarity = formatRarity(monster.rarity);
+  const level = formatLevel(monster.level);
+  const energy = formatNumber(monster.energy);
+  const genes = Array.isArray(monster.genes) ? monster.genes : [];
+
+  return (
+    <article
+      style={{
+        ...cardStyle,
+        transform: highlight ? "translateY(-4px)" : undefined,
+        boxShadow: highlight
+          ? "0 28px 60px rgba(37, 99, 235, 0.35)"
+          : cardStyle.boxShadow,
+        border: highlight
+          ? "1px solid rgba(59, 130, 246, 0.5)"
+          : cardStyle.border,
+      }}
+    >
+      <header style={headerStyle}>
+        <span style={badgeStyle}>{idLabel}</span>
+        {displayName ? <span style={subtitleStyle}>{displayName}</span> : null}
+        <h2 style={titleStyle}>{species}</h2>
+      </header>
+
+      <section>
+        <h3 style={sectionTitleStyle}>基础属性</h3>
+        <div style={statsGridStyle}>
+          <div style={statCardStyle}>
+            <span style={statLabelStyle}>稀有度</span>
+            <strong style={statValueStyle}>{rarity}</strong>
+          </div>
+          <div style={statCardStyle}>
+            <span style={statLabelStyle}>等级</span>
+            <strong style={statValueStyle}>{level}</strong>
+          </div>
+          <div style={statCardStyle}>
+            <span style={statLabelStyle}>能量</span>
+            <strong style={statValueStyle}>{energy}</strong>
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <h3 style={sectionTitleStyle}>基因</h3>
+        {genes.length > 0 ? (
+          <div style={geneListStyle}>
+            {genes.map((gene, index) => (
+              <span key={index} style={geneChipStyle}>
+                {resolveGeneLabel(gene, index)}
+              </span>
+            ))}
+          </div>
+        ) : (
+          <p style={emptyGeneStyle}>暂无基因数据</p>
+        )}
+      </section>
+
+      {footer ? footer : null}
+    </article>
+  );
+};
+
+export default MonsterCard;

--- a/src/lib/monsters.ts
+++ b/src/lib/monsters.ts
@@ -1,0 +1,208 @@
+export type MonsterGene = string | number | Record<string, unknown> | null | undefined;
+
+export type MonsterData = {
+  id: string | number;
+  name?: string | null;
+  nickname?: string | null;
+  species?: string | null;
+  rarity?: string | null;
+  level?: number | null;
+  energy?: number | null;
+  genes?: MonsterGene[] | null;
+  [key: string]: unknown;
+};
+
+export type MonsterRecord = MonsterData & {
+  raw: Record<string, unknown>;
+};
+
+const POSSIBLE_ID_KEYS = ["id", "monsterId", "uuid", "tokenId", "dnaId", "_id"];
+const POSSIBLE_GENE_KEYS = ["genes", "geneTags", "traits", "dna", "geneSequence", "geneList"];
+
+function ensureRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === "object" && !Array.isArray(value);
+}
+
+function toMaybeNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return null;
+    }
+
+    const parsed = Number(trimmed);
+    if (!Number.isNaN(parsed)) {
+      return parsed;
+    }
+  }
+
+  return null;
+}
+
+function toMaybeString(value: unknown): string | null {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+
+  return null;
+}
+
+function extractId(record: Record<string, unknown>, fallbackId: string): string | number {
+  for (const key of POSSIBLE_ID_KEYS) {
+    const value = record[key];
+    if (typeof value === "string" || typeof value === "number") {
+      return value;
+    }
+  }
+
+  return fallbackId;
+}
+
+function extractGenes(record: Record<string, unknown>): MonsterGene[] {
+  for (const key of POSSIBLE_GENE_KEYS) {
+    const value = record[key];
+    if (Array.isArray(value)) {
+      return value as MonsterGene[];
+    }
+
+    if (typeof value === "string") {
+      const parts = value
+        .split(/[,|]/)
+        .map((part) => part.trim())
+        .filter((part) => part.length > 0);
+      if (parts.length > 0) {
+        return parts;
+      }
+    }
+  }
+
+  return [];
+}
+
+function pickFirstString(record: Record<string, unknown>, keys: string[]): string | null {
+  for (const key of keys) {
+    const maybeString = toMaybeString(record[key]);
+    if (maybeString) {
+      return maybeString;
+    }
+  }
+
+  return null;
+}
+
+function pickFirstNumber(record: Record<string, unknown>, keys: string[]): number | null {
+  for (const key of keys) {
+    const maybeNumber = toMaybeNumber(record[key]);
+    if (maybeNumber != null) {
+      return maybeNumber;
+    }
+  }
+
+  return null;
+}
+
+export function normalizeMonster(raw: unknown, fallbackId: string): MonsterRecord | null {
+  if (!ensureRecord(raw)) {
+    return null;
+  }
+
+  const id = extractId(raw, fallbackId);
+  const genes = extractGenes(raw);
+  const levelValue = pickFirstNumber(raw, ["level", "lvl", "rank", "stage"]);
+  const energyValue = pickFirstNumber(raw, ["energy", "stamina", "power", "vitality", "endurance"]);
+  const nameValue = pickFirstString(raw, ["name", "displayName"]);
+  const nicknameValue = pickFirstString(raw, ["nickname", "alias"]);
+  const speciesValue = pickFirstString(raw, ["species", "type", "element"]);
+  const rarityValue = pickFirstString(raw, ["rarity", "tier", "grade", "rarityLevel"]);
+
+  const normalized: MonsterRecord = {
+    id,
+    name: nameValue ?? undefined,
+    nickname: nicknameValue ?? undefined,
+    species: speciesValue ?? undefined,
+    rarity: rarityValue ?? undefined,
+    level: levelValue ?? undefined,
+    energy: energyValue ?? undefined,
+    genes,
+    raw,
+  };
+
+  const descriptionValue = pickFirstString(raw, ["description", "bio", "story"]);
+  if (descriptionValue) {
+    normalized.description = descriptionValue;
+  }
+
+  const statusValue = pickFirstString(raw, ["status", "state"]);
+  if (statusValue) {
+    normalized.status = statusValue;
+  }
+
+  const ownerValue = pickFirstString(raw, ["owner", "trainer", "holder", "walletAddress"]);
+  if (ownerValue) {
+    normalized.owner = ownerValue;
+  }
+
+  const experienceValue = pickFirstNumber(raw, ["experience", "exp"]);
+  if (experienceValue != null) {
+    normalized.experience = experienceValue;
+  } else {
+    const experienceText = pickFirstString(raw, ["experience", "exp"]);
+    if (experienceText) {
+      normalized.experience = experienceText;
+    }
+  }
+
+  const generationValue = pickFirstNumber(raw, ["generation"]);
+  if (generationValue != null) {
+    normalized.generation = generationValue;
+  }
+
+  const createdAtValue = pickFirstString(raw, ["createdAt", "created_at", "created"]);
+  if (createdAtValue) {
+    normalized.createdAt = createdAtValue;
+  }
+
+  const updatedAtValue = pickFirstString(raw, ["updatedAt", "updated_at", "updated"]);
+  if (updatedAtValue) {
+    normalized.updatedAt = updatedAtValue;
+  }
+
+  return normalized;
+}
+
+export function parseMonsterList(payload: unknown): MonsterRecord[] {
+  const items: unknown[] = [];
+
+  if (Array.isArray(payload)) {
+    items.push(...payload);
+  } else if (ensureRecord(payload)) {
+    const candidates = ["monsters", "data", "items", "results", "list", "records"];
+    for (const key of candidates) {
+      const value = payload[key];
+      if (Array.isArray(value)) {
+        items.push(...value);
+      }
+    }
+
+    if (items.length === 0) {
+      for (const value of Object.values(payload)) {
+        if (Array.isArray(value)) {
+          items.push(...value);
+        }
+      }
+    }
+  }
+
+  return items
+    .map((item, index) => normalizeMonster(item, `monster-${index + 1}`))
+    .filter((item): item is MonsterRecord => item != null);
+}


### PR DESCRIPTION
## Summary
- add a refreshed dashboard card that fetches `/wallet` and links into the lab
- implement the lab overview with monster grid, starter claim flow, and shared monster card component
- add a monster detail view backed by normalization utilities for consistent metadata and gene chips

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce15ae3e548330ae1df4e90af5ab06