### PR TITLE
Fix missing JSON payloads for feed and wallet grant requests

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -270,7 +270,13 @@ export default function DashboardPage() {
     setIsGranting(true);
 
     try {
-      const response = await apiFetch("/wallet/grant", { method: "POST" });
+      const response = await apiFetch("/wallet/grant", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ amount: 1000 }),
+      });
       if (!response.ok) {
         const fallback = `加币失败（${response.status}）`;
         const message = await extractErrorMessage(response, fallback);

--- a/src/app/lab/monster/[id]/page.tsx
+++ b/src/app/lab/monster/[id]/page.tsx
@@ -441,6 +441,10 @@ export default function MonsterDetailPage() {
     try {
       const response = await apiFetch(`/monsters/${encodeURIComponent(monsterId)}/feed`, {
         method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ item: "basic-food" }),
       });
 
       if (!response.ok) {


### PR DESCRIPTION
## Summary
- send the basic food item payload when feeding monsters and include the JSON content type header
- provide the amount payload for wallet grant requests so the backend accepts the call

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce38e5105c8330b8a317213c9ebe79