### PR TITLE
feat: wire monster avatars on lab pages

### DIFF
--- a/src/app/lab/monster/[id]/page.tsx
+++ b/src/app/lab/monster/[id]/page.tsx
@@ -10,6 +10,7 @@ import {
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
 import MonsterCard from "@/components/MonsterCard";
+import MonsterAvatar from "@/components/MonsterAvatar";
 import ActionBar from "@/components/ActionBar";
 import { apiFetch } from "@/lib/api";
 import { getToken } from "@/lib/auth";
@@ -38,6 +39,25 @@ const contentStyle: CSSProperties = {
   display: "flex",
   flexDirection: "column",
   gap: "2.25rem",
+};
+
+const heroAvatarShellStyle: CSSProperties = {
+  alignSelf: "center",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+};
+
+const heroAvatarRingStyle: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  padding: "1.4rem",
+  borderRadius: "999px",
+  background: "rgba(15, 23, 42, 0.6)",
+  border: "1px solid rgba(148, 163, 184, 0.32)",
+  boxShadow: "0 36px 75px rgba(15, 23, 42, 0.45)",
+  overflow: "hidden",
 };
 
 const actionRowStyle: CSSProperties = {
@@ -600,6 +620,13 @@ export default function MonsterDetailPage() {
 
         {monster ? (
           <div style={{ display: "flex", flexDirection: "column", gap: "2rem" }}>
+            {monsterId ? (
+              <div style={heroAvatarShellStyle}>
+                <div style={heroAvatarRingStyle}>
+                  <MonsterAvatar id={monsterId} size={160} />
+                </div>
+              </div>
+            ) : null}
             <MonsterCard
               monster={monster}
               highlight

--- a/src/components/MonsterAvatar.tsx
+++ b/src/components/MonsterAvatar.tsx
@@ -1,0 +1,35 @@
+/* eslint-disable @next/next/no-img-element */
+
+import { CSSProperties } from "react";
+import { getApiBaseUrl } from "@/lib/api";
+
+type MonsterAvatarProps = {
+  id: string;
+  size?: number;
+};
+
+const imageStyle: CSSProperties = {
+  display: "block",
+  width: "100%",
+  height: "100%",
+  objectFit: "contain",
+};
+
+export default function MonsterAvatar({ id, size = 96 }: MonsterAvatarProps) {
+  const base = getApiBaseUrl();
+  const path = `/monsters/${encodeURIComponent(id)}/avatar`;
+  const src = base ? `${base}${path}` : path;
+
+  return (
+    <img
+      src={src}
+      width={size}
+      height={size}
+      alt="Monster avatar"
+      style={imageStyle}
+      loading="lazy"
+      decoding="async"
+      draggable={false}
+    />
+  );
+}

--- a/src/components/MonsterCard.tsx
+++ b/src/components/MonsterCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { CSSProperties, ReactNode } from "react";
+import MonsterAvatar from "./MonsterAvatar";
 import { MonsterData, MonsterGene } from "@/lib/monsters";
 
 type MonsterCardProps = {
@@ -22,6 +23,20 @@ const cardStyle: CSSProperties = {
   gap: "1.5rem",
   height: "100%",
   transition: "transform 0.2s ease, box-shadow 0.2s ease",
+};
+
+const avatarWrapperStyle: CSSProperties = {
+  alignSelf: "center",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  padding: "0.8rem",
+  borderRadius: "999px",
+  background: "rgba(15, 23, 42, 0.58)",
+  border: "1px solid rgba(148, 163, 184, 0.28)",
+  boxShadow: "0 24px 48px rgba(15, 23, 42, 0.38)",
+  overflow: "hidden",
+  transition: "box-shadow 0.2s ease, border 0.2s ease, background 0.2s ease",
 };
 
 const headerStyle: CSSProperties = {
@@ -220,6 +235,22 @@ const MonsterCard = ({ monster, footer, highlight = false }: MonsterCardProps) =
           : cardStyle.border,
       }}
     >
+      <div
+        style={{
+          ...avatarWrapperStyle,
+          border: highlight
+            ? "1px solid rgba(59, 130, 246, 0.48)"
+            : avatarWrapperStyle.border,
+          background: highlight
+            ? "rgba(59, 130, 246, 0.18)"
+            : avatarWrapperStyle.background,
+          boxShadow: highlight
+            ? "0 32px 60px rgba(37, 99, 235, 0.38)"
+            : avatarWrapperStyle.boxShadow,
+        }}
+      >
+        <MonsterAvatar id={String(monster.id)} />
+      </div>
       <header style={headerStyle}>
         <span style={badgeStyle}>{idLabel}</span>
         {displayName ? <span style={subtitleStyle}>{displayName}</span> : null}


### PR DESCRIPTION
## Summary
- add a reusable MonsterAvatar component that loads monster SVGs from the API base URL
- embed the avatar in MonsterCard so lab listings render each monster's image
- show an enlarged avatar on the monster detail page for quick visual recognition

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce426015ec8330aaeb514b36da711d