### PR TITLE
Wire bag and shop pages to inventory API

### DIFF
--- a/src/app/lab/monster/[id]/page.tsx
+++ b/src/app/lab/monster/[id]/page.tsx
@@ -14,7 +14,11 @@ import MonsterAvatar from "@/components/MonsterAvatar";
 import ActionBar from "@/components/ActionBar";
 import { apiFetch } from "@/lib/api";
 import { getToken } from "@/lib/auth";
-import { MonsterRecord, normalizeMonster } from "@/lib/monsters";
+import {
+  MonsterRecord,
+  extractMonsterFromPayload,
+  mergeMonsterRecords,
+} from "@/lib/monsters";
 
 const layoutStyle: CSSProperties = {
   minHeight: "100vh",
@@ -487,7 +491,7 @@ export default function MonsterDetailPage() {
         return;
       }
 
-      const normalized = normalizeMonster(payload, String(monsterId));
+      const normalized = extractMonsterFromPayload(payload, String(monsterId));
       if (!normalized) {
         throw new Error("Unexpected monster payload");
       }
@@ -576,7 +580,7 @@ export default function MonsterDetailPage() {
       let updatedMonster: MonsterRecord | null = null;
       if (response.status !== 204) {
         const payload = await response.json();
-        updatedMonster = normalizeMonster(payload, String(monsterId));
+        updatedMonster = extractMonsterFromPayload(payload, String(monsterId));
       }
 
       if (!mountedRef.current) {
@@ -584,8 +588,9 @@ export default function MonsterDetailPage() {
       }
 
       if (updatedMonster) {
-        setMonster(updatedMonster);
-        triggerStatHighlights(snapshot, updatedMonster);
+        const merged = mergeMonsterRecords(snapshot, updatedMonster) ?? updatedMonster;
+        setMonster(merged);
+        triggerStatHighlights(snapshot, merged);
       } else {
         clearStatHighlights();
         void fetchMonster();
@@ -665,7 +670,7 @@ export default function MonsterDetailPage() {
       let updatedMonster: MonsterRecord | null = null;
       if (response.status !== 204) {
         const payload = await response.json();
-        updatedMonster = normalizeMonster(payload, String(monsterId));
+        updatedMonster = extractMonsterFromPayload(payload, String(monsterId));
       }
 
       if (!mountedRef.current) {
@@ -673,8 +678,9 @@ export default function MonsterDetailPage() {
       }
 
       if (updatedMonster) {
-        setMonster(updatedMonster);
-        triggerStatHighlights(snapshot, updatedMonster);
+        const merged = mergeMonsterRecords(snapshot, updatedMonster) ?? updatedMonster;
+        setMonster(merged);
+        triggerStatHighlights(snapshot, merged);
       } else {
         clearStatHighlights();
         void fetchMonster();

--- a/src/lib/monsters.ts
+++ b/src/lib/monsters.ts
@@ -24,6 +24,52 @@ export type MonsterRecord = MonsterData & {
 const POSSIBLE_ID_KEYS = ["id", "monsterId", "uuid", "tokenId", "dnaId", "_id"];
 const POSSIBLE_GENE_KEYS = ["genes", "geneTags", "traits", "dna", "geneSequence", "geneList"];
 
+const LEVEL_KEYS = ["level", "lvl", "rank", "stage"];
+const ENERGY_KEYS = ["energy", "stamina", "power", "vitality", "endurance"];
+const ATTACK_KEYS = ["atk", "attack", "offense", "strength"];
+const DEFENSE_KEYS = ["def", "defense", "guard", "resistance", "protection"];
+const SPEED_KEYS = ["spd", "speed", "agility", "dexterity"];
+const HEALTH_KEYS = ["hp", "health", "hitpoints", "life", "vigor"];
+const RANK_NUMBER_KEYS = ["rank", "ranking", "rankLevel", "rankScore", "score", "value", "current"];
+const RANK_TEXT_KEYS = [
+  "rank",
+  "ranking",
+  "tier",
+  "class",
+  "grade",
+  "rankTitle",
+  "title",
+  "name",
+  "label",
+];
+
+const STAT_CONTAINER_KEYS = [
+  "stats",
+  "attributes",
+  "statistics",
+  "baseStats",
+  "base_stats",
+  "details",
+  "info",
+  "profile",
+  "meta",
+  "properties",
+  "values",
+  "metrics",
+  "numbers",
+  "combat",
+  "combatStats",
+  "combat_stats",
+  "battleStats",
+  "battle_stats",
+  "power",
+  "growth",
+  "performance",
+  "summary",
+  "overview",
+  "data",
+];
+
 function ensureRecord(value: unknown): value is Record<string, unknown> {
   return value != null && typeof value === "object" && !Array.isArray(value);
 }
@@ -115,6 +161,98 @@ function pickFirstNumber(record: Record<string, unknown>, keys: string[]): numbe
   return null;
 }
 
+function collectStatContainers(
+  source: Record<string, unknown>,
+  bucket: Record<string, unknown>[],
+  seen: WeakSet<Record<string, unknown>>,
+): void {
+  if (seen.has(source)) {
+    return;
+  }
+
+  seen.add(source);
+
+  for (const key of STAT_CONTAINER_KEYS) {
+    const value = source[key];
+
+    if (Array.isArray(value)) {
+      for (const entry of value) {
+        if (ensureRecord(entry) && !seen.has(entry)) {
+          bucket.push(entry);
+          collectStatContainers(entry, bucket, seen);
+        }
+      }
+      continue;
+    }
+
+    if (ensureRecord(value) && !seen.has(value)) {
+      bucket.push(value);
+      collectStatContainers(value, bucket, seen);
+    }
+  }
+}
+
+function fillStatsFromContainers(
+  normalized: MonsterRecord,
+  containers: Record<string, unknown>[],
+): void {
+  for (const container of containers) {
+    if (normalized.energy == null) {
+      const candidate = pickFirstNumber(container, ENERGY_KEYS);
+      if (candidate != null) {
+        normalized.energy = candidate;
+      }
+    }
+
+    if (normalized.level == null) {
+      const candidate = pickFirstNumber(container, LEVEL_KEYS);
+      if (candidate != null) {
+        normalized.level = candidate;
+      }
+    }
+
+    if (normalized.atk == null) {
+      const candidate = pickFirstNumber(container, ATTACK_KEYS);
+      if (candidate != null) {
+        normalized.atk = candidate;
+      }
+    }
+
+    if (normalized.def == null) {
+      const candidate = pickFirstNumber(container, DEFENSE_KEYS);
+      if (candidate != null) {
+        normalized.def = candidate;
+      }
+    }
+
+    if (normalized.spd == null) {
+      const candidate = pickFirstNumber(container, SPEED_KEYS);
+      if (candidate != null) {
+        normalized.spd = candidate;
+      }
+    }
+
+    if (normalized.hp == null) {
+      const candidate = pickFirstNumber(container, HEALTH_KEYS);
+      if (candidate != null) {
+        normalized.hp = candidate;
+      }
+    }
+
+    if (normalized.rank == null) {
+      const rankNumber = pickFirstNumber(container, RANK_NUMBER_KEYS);
+      if (rankNumber != null) {
+        normalized.rank = rankNumber;
+      } else {
+        const rankText = pickFirstString(container, RANK_TEXT_KEYS);
+        if (rankText) {
+          normalized.rank = rankText;
+        }
+      }
+    }
+  }
+}
+
 export function normalizeMonster(raw: unknown, fallbackId: string): MonsterRecord | null {
   if (!ensureRecord(raw)) {
     return null;
@@ -122,18 +260,18 @@ export function normalizeMonster(raw: unknown, fallbackId: string): MonsterRecor
 
   const id = extractId(raw, fallbackId);
   const genes = extractGenes(raw);
-  const levelValue = pickFirstNumber(raw, ["level", "lvl", "rank", "stage"]);
-  const energyValue = pickFirstNumber(raw, ["energy", "stamina", "power", "vitality", "endurance"]);
+  const levelValue = pickFirstNumber(raw, LEVEL_KEYS);
+  const energyValue = pickFirstNumber(raw, ENERGY_KEYS);
   const nameValue = pickFirstString(raw, ["name", "displayName"]);
   const nicknameValue = pickFirstString(raw, ["nickname", "alias"]);
   const speciesValue = pickFirstString(raw, ["species", "type", "element"]);
   const rarityValue = pickFirstString(raw, ["rarity", "tier", "grade", "rarityLevel"]);
-  const rankNumber = pickFirstNumber(raw, ["rank", "ranking", "rankLevel", "rankScore"]);
-  const rankString = pickFirstString(raw, ["rank", "ranking", "tier", "class", "grade", "rankTitle"]);
-  const attackValue = pickFirstNumber(raw, ["atk", "attack", "offense", "strength"]);
-  const defenseValue = pickFirstNumber(raw, ["def", "defense", "guard", "resistance", "protection"]);
-  const speedValue = pickFirstNumber(raw, ["spd", "speed", "agility", "dexterity"]);
-  const healthValue = pickFirstNumber(raw, ["hp", "health", "hitpoints", "life", "vigor"]);
+  const rankNumber = pickFirstNumber(raw, RANK_NUMBER_KEYS);
+  const rankString = pickFirstString(raw, RANK_TEXT_KEYS);
+  const attackValue = pickFirstNumber(raw, ATTACK_KEYS);
+  const defenseValue = pickFirstNumber(raw, DEFENSE_KEYS);
+  const speedValue = pickFirstNumber(raw, SPEED_KEYS);
+  const healthValue = pickFirstNumber(raw, HEALTH_KEYS);
 
   const normalized: MonsterRecord = {
     id,
@@ -151,6 +289,12 @@ export function normalizeMonster(raw: unknown, fallbackId: string): MonsterRecor
     genes,
     raw,
   };
+
+  const statContainers: Record<string, unknown>[] = [];
+  collectStatContainers(raw, statContainers, new WeakSet());
+  if (statContainers.length > 0) {
+    fillStatsFromContainers(normalized, statContainers);
+  }
 
   const descriptionValue = pickFirstString(raw, ["description", "bio", "story"]);
   if (descriptionValue) {
@@ -221,4 +365,153 @@ export function parseMonsterList(payload: unknown): MonsterRecord[] {
   return items
     .map((item, index) => normalizeMonster(item, `monster-${index + 1}`))
     .filter((item): item is MonsterRecord => item != null);
+}
+
+const MONSTER_PAYLOAD_KEYS = [
+  "monster",
+  "data",
+  "result",
+  "record",
+  "entity",
+  "updated",
+  "updatedMonster",
+  "target",
+  "response",
+  "payload",
+  "body",
+];
+
+function extractMonsterFromPayloadInternal(
+  payload: unknown,
+  fallbackId: string,
+  seen: WeakSet<object>,
+): MonsterRecord | null {
+  const direct = normalizeMonster(payload, fallbackId);
+  if (direct) {
+    return direct;
+  }
+
+  if (Array.isArray(payload)) {
+    if (seen.has(payload as unknown as object)) {
+      return null;
+    }
+    seen.add(payload as unknown as object);
+
+    for (const entry of payload) {
+      const candidate = extractMonsterFromPayloadInternal(entry, fallbackId, seen);
+      if (candidate) {
+        return candidate;
+      }
+    }
+    return null;
+  }
+
+  if (!ensureRecord(payload)) {
+    return null;
+  }
+
+  if (seen.has(payload)) {
+    return null;
+  }
+  seen.add(payload);
+
+  for (const key of MONSTER_PAYLOAD_KEYS) {
+    if (!(key in payload)) {
+      continue;
+    }
+
+    const candidate = extractMonsterFromPayloadInternal(payload[key], fallbackId, seen);
+    if (candidate) {
+      return candidate;
+    }
+  }
+
+  for (const value of Object.values(payload)) {
+    if (value == null) {
+      continue;
+    }
+
+    if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+      continue;
+    }
+
+    const candidate = extractMonsterFromPayloadInternal(value, fallbackId, seen);
+    if (candidate) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+export function extractMonsterFromPayload(
+  payload: unknown,
+  fallbackId: string,
+): MonsterRecord | null {
+  return extractMonsterFromPayloadInternal(payload, fallbackId, new WeakSet());
+}
+
+const MERGE_PRESERVE_KEYS: (keyof MonsterRecord)[] = [
+  "atk",
+  "def",
+  "spd",
+  "hp",
+  "rank",
+  "energy",
+  "level",
+  "experience",
+];
+
+function shouldPreserveValue(value: unknown): boolean {
+  if (value == null) {
+    return true;
+  }
+
+  if (typeof value === "number") {
+    return !Number.isFinite(value);
+  }
+
+  if (typeof value === "string") {
+    return value.trim().length === 0;
+  }
+
+  return false;
+}
+
+export function mergeMonsterRecords(
+  previous: MonsterRecord | null,
+  incoming: MonsterRecord | null,
+): MonsterRecord | null {
+  if (!previous && !incoming) {
+    return null;
+  }
+
+  if (!previous) {
+    return incoming;
+  }
+
+  if (!incoming) {
+    return previous;
+  }
+
+  const merged: MonsterRecord = {
+    ...previous,
+    ...incoming,
+    raw: {
+      ...previous.raw,
+      ...incoming.raw,
+    },
+  };
+
+  for (const key of MERGE_PRESERVE_KEYS) {
+    const incomingValue = incoming[key];
+    if (shouldPreserveValue(incomingValue)) {
+      const previousValue = previous[key];
+      if (previousValue !== undefined && previousValue !== null) {
+        (merged as Record<string, unknown>)[key] = previousValue as unknown;
+      }
+    }
+  }
+
+  return merged;
 }


### PR DESCRIPTION
## Summary
- update the bag page to fetch `/inventory`, reuse monster helpers, and keep monsters in sync after feeding
- refresh the shop page via `/inventory` and prefer `/shop/buy` for purchases while updating inventory and wallet states
- enhance monster parsing utilities and detail view to extract nested stats and merge payload data without losing values

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ced80780e483308b3fb4ef5c624cf0