### PR TITLE
feat: refresh feed results and surface evolutions

### DIFF
--- a/src/components/MonsterAvatar.tsx
+++ b/src/components/MonsterAvatar.tsx
@@ -6,6 +6,7 @@ import { getApiBaseUrl } from "@/lib/api";
 type MonsterAvatarProps = {
   id: string;
   size?: number;
+  appearanceRevision?: number | string | null;
 };
 
 const imageStyle: CSSProperties = {
@@ -15,10 +16,19 @@ const imageStyle: CSSProperties = {
   objectFit: "contain",
 };
 
-export default function MonsterAvatar({ id, size = 96 }: MonsterAvatarProps) {
+export default function MonsterAvatar({ id, size = 96, appearanceRevision }: MonsterAvatarProps) {
   const base = getApiBaseUrl();
   const path = `/monsters/${encodeURIComponent(id)}/avatar`;
-  const src = base ? `${base}${path}` : path;
+  const revisionValue =
+    typeof appearanceRevision === "number"
+      ? Number.isFinite(appearanceRevision)
+        ? String(appearanceRevision)
+        : null
+      : typeof appearanceRevision === "string"
+        ? appearanceRevision.trim() || null
+        : null;
+  const baseSrc = base ? `${base}${path}` : path;
+  const src = revisionValue ? `${baseSrc}?rev=${encodeURIComponent(revisionValue)}` : baseSrc;
 
   return (
     <img

--- a/src/components/MonsterCard.tsx
+++ b/src/components/MonsterCard.tsx
@@ -332,7 +332,7 @@ const MonsterCard = ({ monster, footer, highlight = false, statHighlights }: Mon
             : avatarWrapperStyle.boxShadow,
         }}
       >
-        <MonsterAvatar id={String(monster.id)} />
+        <MonsterAvatar id={String(monster.id)} appearanceRevision={monster.appearanceRevision} />
       </div>
       <header style={headerStyle}>
         <div style={badgeRowStyle}>


### PR DESCRIPTION
## Summary
- normalize monster payloads to capture stage and appearance revisions and expose helpers for extracting evolution results
- refresh monster avatar URLs with the latest appearance revision so cards show new art instantly
- update the lab and bag feed flows to use response data, sync inventory, and surface evolution success messaging

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68cf5cec0b288330909b89668304ac26